### PR TITLE
Show shelter by id

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -4,5 +4,6 @@
     end
 
     def show
+      @shelter = Shelter.find(params[:id])
     end
   end

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -2,4 +2,7 @@
     def index
       @shelters = Shelter.all
     end
+
+    def show
+    end
   end

--- a/app/views/shelters/index.html.erb
+++ b/app/views/shelters/index.html.erb
@@ -1,5 +1,5 @@
 <h1>All Shelters</h1>
 
 <% @shelters.each do |shelter| %>
-  <h2><%= shelter.name %></h2>
+  <h2><a href="/shelters/<%= shelter.id %>"><%= shelter.name %></a></h2>
 <% end %>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -3,3 +3,5 @@
 <h2>Address:</h2>
 <p><%= @shelter.address %></p>
 <p><%= "#{@shelter.city}, #{@shelter.state} #{@shelter.zip}" %></p>
+
+<a href="/shelters">Shelter Index</a>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -1,0 +1,5 @@
+<h1><%= @shelter.name %></h1>
+
+<h2>Address:</h2>
+<p><%= @shelter.address %></p>
+<p><%= "#{@shelter.city}, #{@shelter.state} #{@shelter.zip}" %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   get '/shelters', to: 'shelters#index'
+  get '/shelters/:id', to: 'shelters#show'
 end

--- a/spec/features/shelters/index_spec.rb
+++ b/spec/features/shelters/index_spec.rb
@@ -2,13 +2,15 @@ require 'rails_helper'
 
 RSpec.describe "shelters index page", type: :feature do 
   it "can see all shelters' names" do
-    shelter_1 = Shelter.create(name: "Rocky Mountain Puppy Rescue",
+    shelter_1 = Shelter.create(id: 1,
+                               name: "Rocky Mountain Puppy Rescue",
                                address: "10021 E Iliff Ave",
                                city: "Aurora",
                                state: "CO",
                                zip: "80247")
     
-    shelter_2 = Shelter.create(name: "Espiritu Alpacas",
+    shelter_2 = Shelter.create(id: 2,
+                               name: "Espiritu Alpacas",
                                address: "8221 S Blue Creek Rd",
                                city: "Evergreen",
                                state: "CO",
@@ -18,5 +20,26 @@ RSpec.describe "shelters index page", type: :feature do
 
     expect(page).to have_content(shelter_1.name)
     expect(page).to have_content(shelter_2.name)
+  end
+
+  it "can can show one shelter" do
+    shelter_1 = Shelter.create(id: 1,
+                               name: "Rocky Mountain Puppy Rescue",
+                               address: "10021 E Iliff Ave",
+                               city: "Aurora",
+                               state: "CO",
+                               zip: "80247")
+    
+    shelter_2 = Shelter.create(id: 2,
+                               name: "Espiritu Alpacas",
+                               address: "8221 S Blue Creek Rd",
+                               city: "Evergreen",
+                               state: "CO",
+                               zip: "80439")
+
+    visit "/shelters"
+
+    expect(page).to have_link(href: "/shelters/1")
+    expect(page).to have_link(href: "/shelters/2")
   end
 end

--- a/spec/features/shelters/user_can_see_one_shelter_spec.rb
+++ b/spec/features/shelters/user_can_see_one_shelter_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe "show shelter by id page", type: :feature do
   it "can see all shelter's name and address" do
     shelter_1 = Shelter.create(name: "Rocky Mountain Puppy Rescue",
                                address: "10021 E Iliff Ave",
-                               city: "Aurora"
-                               state: "CO"
+                               city: "Aurora",
+                               state: "CO",
                                zip: "80247")
 
     visit "/shelters/shelter_1"

--- a/spec/features/shelters/user_can_see_one_shelter_spec.rb
+++ b/spec/features/shelters/user_can_see_one_shelter_spec.rb
@@ -18,4 +18,18 @@ RSpec.describe "show shelter by id page", type: :feature do
     expect(page).to have_content(shelter_1.state)
     expect(page).to have_content(shelter_1.zip)
   end
+
+  it "can link back to shelter index" do
+    shelter_1 = Shelter.create(id: 1,
+                               # is adding the id num above what I should be doing? 
+                               name: "Rocky Mountain Puppy Rescue",
+                               address: "10021 E Iliff Ave",
+                               city: "Aurora",
+                               state: "CO",
+                               zip: "80247")
+
+    visit "/shelters/1"
+
+    expect(page).to have_link(href: "/shelters")
+  end
 end

--- a/spec/features/shelters/user_can_see_one_shelter_spec.rb
+++ b/spec/features/shelters/user_can_see_one_shelter_spec.rb
@@ -2,13 +2,15 @@ require 'rails_helper'
 
 RSpec.describe "show shelter by id page", type: :feature do 
   it "can see all shelter's name and address" do
-    shelter_1 = Shelter.create(name: "Rocky Mountain Puppy Rescue",
+    shelter_1 = Shelter.create(id: 1,
+                               # is adding the id num above what I should be doing? 
+                               name: "Rocky Mountain Puppy Rescue",
                                address: "10021 E Iliff Ave",
                                city: "Aurora",
                                state: "CO",
                                zip: "80247")
 
-    visit "/shelters/shelter_1"
+    visit "/shelters/1"
 
     expect(page).to have_content(shelter_1.name)
     expect(page).to have_content(shelter_1.address)


### PR DESCRIPTION
Added tests and functionality for below: 
- view individual shelter's details (name and address) when navigating to /shelters/:id or by clicking on shelter's name in shelter index
- link back to shelter index from shelter details 

closes #3 