### PR TITLE
Delete shelter

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -44,4 +44,10 @@
 
       redirect_to "/shelters/#{shelter.id}"
     end
+
+    def destroy
+      Shelter.destroy(params[:id])
+      
+      redirect_to "/shelters"
+    end
   end

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -47,7 +47,7 @@
 
     def destroy
       Shelter.destroy(params[:id])
-
+      
       redirect_to "/shelters"
     end
   end

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -47,7 +47,7 @@
 
     def destroy
       Shelter.destroy(params[:id])
-      
+
       redirect_to "/shelters"
     end
   end

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -4,5 +4,6 @@
 <p><%= @shelter.address %></p>
 <p><%= "#{@shelter.city}, #{@shelter.state} #{@shelter.zip}" %></p>
 
-<a href="/shelters/<%= @shelter.id %>/edit">Update Shelter</a>
+<a href="/shelters/<%= @shelter.id %>/edit">Update Shelter</a></br>
+<a href="/shelters/<%= @shelter.id %>/delete">Delete Shelter</a></br>
 <a href="/shelters">Shelter Index</a>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -5,5 +5,7 @@
 <p><%= "#{@shelter.city}, #{@shelter.state} #{@shelter.zip}" %></p>
 
 <a href="/shelters/<%= @shelter.id %>/edit">Update Shelter</a></br>
-<a href="/shelters/<%= @shelter.id %>/delete">Delete Shelter</a></br>
+
+<%= link_to "Delete Shelter", "/shelters/#{@shelter.id}", method: :delete, data: {confirm: "Are you sure you want to delete this shelter?"} %></br>
+
 <a href="/shelters">Shelter Index</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,5 @@ Rails.application.routes.draw do
 
   get '/shelters/:id/edit', to:'shelters#edit'
   patch '/shelters/:id', to: 'shelters#update'
-  delete '/shelters', to: 'shelters#destroy'
+  delete '/shelters/:id', to: 'shelters#destroy'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
 
   get '/shelters/:id/edit', to:'shelters#edit'
   patch '/shelters/:id', to: 'shelters#update'
+  delete '/shelters', to: 'shelters#destroy'
 end

--- a/spec/features/shelters/user_can_see_one_shelter_spec.rb
+++ b/spec/features/shelters/user_can_see_one_shelter_spec.rb
@@ -2,17 +2,17 @@ require 'rails_helper'
 
 RSpec.describe "show shelter by id page", type: :feature do
   before :each do 
-    @shelter_1 = Shelter.create(id: 1,
-    # is adding the id num above what I should be doing? 
-    name: "Rocky Mountain Puppy Rescue",
-    address: "10021 E Iliff Ave",
-    city: "Aurora",
-    state: "CO",
-    zip: "80247")
+    @shelter_1 = Shelter.create(
+                                name: "Rocky Mountain Puppy Rescue",
+                                address: "10021 E Iliff Ave",
+                                city: "Aurora",
+                                state: "CO",
+                                zip: "80247"
+                              )
   end
 
   it "can see the shelter's name and address" do
-    visit "/shelters/1"
+    visit "/shelters/#{@shelter_1.id}"
 
     expect(page).to have_content(@shelter_1.name)
     expect(page).to have_content(@shelter_1.address)
@@ -22,20 +22,23 @@ RSpec.describe "show shelter by id page", type: :feature do
   end
 
   it "can link back to shelter index" do
-    visit "/shelters/1"
+    visit "/shelters/#{@shelter_1.id}"
 
     expect(page).to have_link(href: "/shelters")
   end
 
   it "can link to form for updating its attributes" do
-    visit "/shelters/1"
+    visit "/shelters/#{@shelter_1.id}"
 
-    expect(page).to have_link(href: "/shelters/1/edit")
+    expect(page).to have_link(href: "/shelters/#{@shelter_1.id}/edit")
   end
 
-  it "has link for deleting the it" do
-    visit "/shelters/1"
+  it "can be deleted" do
+    visit "/shelters/#{@shelter_1.id}"
+    click_link "Delete Shelter"
 
-    expect(page).to have_content("Delete Shelter")
+    expect(current_path).to eq("/shelters")    
+    expect(page).to_not have_content(@shelter_1.name)
+    expect(page).to_not have_link("Delete Shelter")
   end
 end

--- a/spec/features/shelters/user_can_see_one_shelter_spec.rb
+++ b/spec/features/shelters/user_can_see_one_shelter_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "show shelter by id page", type: :feature do
 
     expect(current_path).to eq("/shelters")    
     expect(page).to_not have_content(@shelter_1.name)
+    # expectation above assumes that shelter names are unique
     expect(page).to_not have_link("Delete Shelter")
   end
 end

--- a/spec/features/shelters/user_can_see_one_shelter_spec.rb
+++ b/spec/features/shelters/user_can_see_one_shelter_spec.rb
@@ -32,4 +32,10 @@ RSpec.describe "show shelter by id page", type: :feature do
 
     expect(page).to have_link(href: "/shelters/1/edit")
   end
+
+  it "has link for deleting the it" do
+    visit "/shelters/1"
+
+    expect(page).to have_link(href: "/shelters/1/delete")
+  end
 end

--- a/spec/features/shelters/user_can_see_one_shelter_spec.rb
+++ b/spec/features/shelters/user_can_see_one_shelter_spec.rb
@@ -36,6 +36,6 @@ RSpec.describe "show shelter by id page", type: :feature do
   it "has link for deleting the it" do
     visit "/shelters/1"
 
-    expect(page).to have_link(href: "/shelters/1/delete")
+    expect(page).to have_content("Delete Shelter")
   end
 end


### PR DESCRIPTION
Added tests and functionality for below:

- deleting existing shelter from /shelters/:id by clicking on "Delete Shelter" link from show shelter by id page
- return to show shelter index page after submitting changes
    -**Note on test/spec for deleting shelter: 
Wasn't sure yet how to create a test for confirming that shelter was deleted other than a few view-type tests (leads to /shelters, shelters index doesn't have deleted name and doesn't have link to delete shelter) so #6 isn't quite finished. I could verify by looking at the db, but don't have an automated test.**