### PR TITLE
Delete pet

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -49,4 +49,10 @@ class PetsController < ApplicationController
 
     redirect_to "/pets/#{pet.id}"
   end
+
+  def destroy 
+    Pet.destroy(params[:id])
+      
+    redirect_to "/pets"
+  end
 end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -33,4 +33,20 @@ class PetsController < ApplicationController
   def edit 
     @pet = Pet.find(params[:id])
   end
+
+  def update
+    pet = Pet.find(params[:id])
+      
+    pet.update({
+      name: params[:name],
+      image: params[:image],
+      description: params[:description],
+      approximate_age: params[:approximate_age],
+      sex: params[:sex]
+      })
+
+    pet.save
+
+    redirect_to "/pets/#{pet.id}"
+  end
 end

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -10,3 +10,4 @@
 </ul>
 
 <a href="/pets/<%= @pet.id %>/edit">Update Pet</a></br>
+<%= link_to "Delete Pet", "/pets/#{@pet.id}", method: :delete, data: {confirm: "Are you sure you want to delete this pet?"} %></br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,5 @@ Rails.application.routes.draw do
   post '/shelters/:id/pets', to: 'pets#create'
   get '/pets/:id/edit', to:'pets#edit'
   patch '/pets/:id', to: 'pets#update'
+  delete '/pets/:id', to: 'pets#destroy'
 end

--- a/spec/features/pets/user_can_see_one_pet_spec.rb
+++ b/spec/features/pets/user_can_see_one_pet_spec.rb
@@ -35,4 +35,13 @@ RSpec.describe "show a shelter's pets page", type: :feature do
   it "can link to form for updating its attributes" do
     expect(page).to have_link(href: "/pets/#{@pet_1.id}/edit")
   end
+
+  it "can be deleted" do
+    click_link "Delete Pet"
+
+    expect(current_path).to eq("/pets")    
+    expect(page).to_not have_content(@pet_1.name)
+    # expectation above assumes that shelter names are unique
+    expect(page).to_not have_link("Delete Pet") 
+  end
 end


### PR DESCRIPTION
Tests and functionality for:
- User can delete a pet when on show pet by id page 
- After deletion, redirected to pet index 
- Deleted pet name does not appear on index (assumes unique pet names) 

closes #12