### PR TITLE
Global show shelter

### DIFF
--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -5,7 +5,7 @@
   <%= image_tag pet.image %>
   <p>Age: <%= pet.approximate_age %></p>
   <p>Sex: <%= pet.sex %></p>
-  <p>Shelter: <%= pet.shelter.name %></p>
+  <p>Shelter: <a href="/shelters/<%= pet.shelter.id %>"><%= pet.shelter.name %></a></p>
   <a href="/pets/<%= pet.id %>/edit">Update Pet</a></br>
   <%= link_to "Delete Pet", "/pets/#{pet.id}", method: :delete, data: {confirm: "Are you sure you want to delete this pet?"} %></br>
 <% end %>

--- a/spec/features/pets/index_spec.rb
+++ b/spec/features/pets/index_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "pets index page", type: :feature do
     expect(page).to have_content(@pet_1.approximate_age)
     expect(page).to have_content(@pet_1.sex)
     expect(page).to have_content(@pet_1.shelter.name)
-    expect(page).to have_linke(href: "/shelters/#{@pet_1.shelter.id}")
+    expect(page).to have_link(href: "/shelters/#{@pet_1.shelter.id}")
 
     expect(page).to have_css("img[src*='https://i.pinimg.com/564x/2e/94/aa/2e94aaff89dcf73b17de85b17cddc038.jpg']")
     expect(page).to have_content(@pet_2.name)


### PR DESCRIPTION
Shelter name should always link to show shelter by id page. This existed without link on the pet index page so I added test and link for it. 

Wish there was some sort of global test that I could use for testing by html class? 

closes #17 